### PR TITLE
Use longer read interval for capacitive soil moisture sensor v1.2

### DIFF
--- a/main/Kconfig
+++ b/main/Kconfig
@@ -159,7 +159,7 @@ menu "Bonsai Firmware Sensor Configuration"
 
         config BONSAI_FIRMWARE_SENSOR_CAPACITIVE_V1_2_READ_INTERVAL
             int "Capacitive V1.2 sensor read interval, in seconds"
-            default 5
+            default 300
             depends on BONSAI_FIRMWARE_SENSOR_CAPACITIVE_V1_2_ENABLE
             help
                 How often to read data from the sensor.


### PR DESCRIPTION
A longer reading interval allows the sensor to stabilise between readings, reducing noise and drift.