### PR TITLE
Decrease maximum value for capacitive soil sensor

### DIFF
--- a/main/Kconfig
+++ b/main/Kconfig
@@ -174,7 +174,7 @@ menu "Bonsai Firmware Sensor Configuration"
 
         config BONSAI_FIRMWARE_SENSOR_CAPACITIVE_V1_2_VALUE_MAX
             int "Capacitive V1.2 sensor soil dryness threshold"
-            default 620
+            default 540
             depends on BONSAI_FIRMWARE_SENSOR_CAPACITIVE_V1_2_ENABLE
             help
                 Value of completely dry soil.


### PR DESCRIPTION
Initially I did the following measurements. I measured the sensor voltage in the air, then in the water. So, I received two extreme points based on which all the calculations are made. In fact, it takes a lot of time for the capacitive sensor to reach the voltage level in the air and when it will finally reach it, I believe, that my plants will be dead. That's why I've decided to decrease the maximum value a bit.